### PR TITLE
Fix tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "! sass test/hsluv-tests.scss | grep '✖ FAILED'"
+    "test": "node test.js"
   },
   "author": "Cameron Little <cameron@camlittle.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "sass test/hsluv-tests.scss"
+    "test": "! sass test/hsluv-tests.scss | grep '✖ FAILED'"
   },
   "author": "Cameron Little <cameron@camlittle.com>",
   "license": "MIT",

--- a/test.js
+++ b/test.js
@@ -1,0 +1,19 @@
+var path = require("path");
+var sassTrue = require("sass-true");
+
+var sassFile = path.join(__dirname, "test", "hsluv-tests.scss");
+sassTrue.runSass(
+  { file: sassFile },
+  {
+    describe(label, block) {
+      console.group(label);
+      block();
+      console.groupEnd();
+    },
+    it(label, block) {
+      console.group("it", label);
+      block();
+      console.groupEnd();
+    },
+  }
+);

--- a/test/_api-test.scss
+++ b/test/_api-test.scss
@@ -3,6 +3,10 @@
 @import "../src/hsluv";
 
 @include describe("hsluv function") {
+  @include it('should fail') {
+    @include assert-false(true);
+  }
+
   @include it('should return SASS color') {
     @include assert-equal(type-of(hsluv(0deg, 0, 0)), color);
   }

--- a/test/_api-test.scss
+++ b/test/_api-test.scss
@@ -3,10 +3,6 @@
 @import "../src/hsluv";
 
 @include describe("hsluv function") {
-  @include it('should fail') {
-    @include assert-false(true);
-  }
-
   @include it('should return SASS color') {
     @include assert-equal(type-of(hsluv(0deg, 0, 0)), color);
   }


### PR DESCRIPTION
I discovered that using sass-true means tests failures won't fail the test script. Looks like sass-true is sort of intended to be passed to a js test runner. I added a minimal (zero-dependency) one.
