### PR TITLE
Add documentation to primary README, minor api changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,11 +95,12 @@ Creates a sass color object in HPLuv color space with transparency.
 - `$lightness` — The lightness of the color. Must be a number between 0% and 100%, inclusive.
 - `$alpha` - The opacity of the color. Must be a number between 0 and 1, inclusive.
 
-All function support passing an HSL map directly and omitting the `$saturation` and `$lightness` parameters.
+All function support passing an HSL map directly and omitting the `$saturation` and `$lightness` parameters. If unitless, the `h` value must be in radians.
 
 ```scss
 .example {
-  color: hsluv((h: 23.2, s: 83.4, l: 43.7))
+  color: hsluv((h: 0.4049164, s: 83.4, l: 43.7));
+  background-color: hpluv((h: 4.3703044, s: 100, l: 59.1));
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,50 +21,6 @@ include
 npm install hsluv-sass
 ```
 
-### API
-
-```scss
-hsluv($hue, $saturation, $lightness) //=> color
-```
-
-Creates a sass color object in HSLuv color space. 
-
-- `$hue` — The hue of the color. A number between 0 and 360 degrees, inclusive.
-- `$saturation` — The saturation of the color. Must be a number between 0% and 100%, inclusive.
-- `$lightness` — The lightness of the color. Must be a number between 0% and 100%, inclusive.
-
-```scss
-hpluv($hue, $saturation, $lightness) //=> color
-```
-
-Creates a sass color object in HPLuv color space. 
-
-- `$hue` — The hue of the color. A number between 0 and 360 degrees, inclusive.
-- `$saturation` — The saturation of the color. Must be a number between 0% and 100%, inclusive.
-- `$lightness` — The lightness of the color. Must be a number between 0% and 100%, inclusive.
-
-```scss
-hsluva($hue, $saturation, $lightness, $alpha: 1) //=> color
-```
-
-Creates a sass color object in HSLuv color space with transparency.
-
-- `$hue` — The hue of the color. A number between 0 and 360 degrees, inclusive.
-- `$saturation` — The saturation of the color. Must be a number between 0% and 100%, inclusive.
-- `$lightness` — The lightness of the color. Must be a number between 0% and 100%, inclusive.
-- `$alpha` - The opacity of the color. Must be a number between 0 and 1, inclusive.
-
-```scss
-hpluva($hue, $saturation, $lightness, $alpha: 1) //=> color
-```
-
-Creates a sass color object in HPLuv color space with transparency. 
-
-- `$hue` — The hue of the color. A number between 0 and 360 degrees, inclusive.
-- `$saturation` — The saturation of the color. Must be a number between 0% and 100%, inclusive.
-- `$lightness` — The lightness of the color. Must be a number between 0% and 100%, inclusive.
-- `$alpha` - The opacity of the color. Must be a number between 0 and 1, inclusive.
-
 ### Example
 
 Create `demo.csss`:
@@ -91,11 +47,59 @@ With [`@import`](https://sass-lang.com/documentation/at-rules/import):
 }
 ```
 
+Compile:
+
 ```bash
 $ npx sass demo.scss 
+```
+
+Emitted css:
+
+```css
 .example {
   color: #a84c27;
   background-color: #738fc0;
+}
+```
+
+### API
+
+```scss
+hsluv($hue, $saturation, $lightness) //=> color
+```
+
+Creates a sass color object in HSLuv color space. 
+
+```scss
+hpluv($hue, $saturation, $lightness) //=> color
+```
+
+Creates a sass color object in HPLuv color space. 
+
+```scss
+hsluva($hue, $saturation, $lightness, $alpha: 1) //=> color
+```
+
+Creates a sass color object in HSLuv color space with transparency.
+
+```scss
+hpluva($hue, $saturation, $lightness, $alpha: 1) //=> color
+```
+
+Creates a sass color object in HPLuv color space with transparency. 
+
+#### Parameters
+
+- `$hue` — The hue of the color. A number between 0 and 360 degrees, inclusive.
+- `$saturation` — The saturation of the color. Must be a number between 0% and 100%, inclusive.
+- `$lightness` — The lightness of the color. Must be a number between 0% and 100%, inclusive.
+- `$alpha` - The opacity of the color. Must be a number between 0 and 1, inclusive.
+
+All function support passing an HSL map directly and omitting the `$saturation` and `$lightness` parameters.
+
+```scss
+.example {
+  color: hsluv((h: 23.2, s: 83.4, l: 43.7))
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,17 +15,72 @@ include
 
 ## Usage
 
-Some [docs](https://github.com/hsluv/hsluv-sass/wiki) for you to read.
-
 ### Installation
 
 ```
 npm install hsluv-sass
 ```
 
+### API
+
+```scss
+hsluv($hue, $saturation, $lightness) //=> color
+```
+
+Creates a sass color object in HSLuv color space. 
+
+- `$hue` — The hue of the color. A number between 0 and 360 degrees, inclusive.
+- `$saturation` — The saturation of the color. Must be a number between 0% and 100%, inclusive.
+- `$lightness` — The lightness of the color. Must be a number between 0% and 100%, inclusive.
+
+```scss
+hpluv($hue, $saturation, $lightness) //=> color
+```
+
+Creates a sass color object in HPLuv color space. 
+
+- `$hue` — The hue of the color. A number between 0 and 360 degrees, inclusive.
+- `$saturation` — The saturation of the color. Must be a number between 0% and 100%, inclusive.
+- `$lightness` — The lightness of the color. Must be a number between 0% and 100%, inclusive.
+
+```scss
+hsluva($hue, $saturation, $lightness, $alpha: 1) //=> color
+```
+
+Creates a sass color object in HSLuv color space with transparency.
+
+- `$hue` — The hue of the color. A number between 0 and 360 degrees, inclusive.
+- `$saturation` — The saturation of the color. Must be a number between 0% and 100%, inclusive.
+- `$lightness` — The lightness of the color. Must be a number between 0% and 100%, inclusive.
+- `$alpha` - The opacity of the color. Must be a number between 0 and 1, inclusive.
+
+```scss
+hpluva($hue, $saturation, $lightness, $alpha: 1) //=> color
+```
+
+Creates a sass color object in HPLuv color space with transparency. 
+
+- `$hue` — The hue of the color. A number between 0 and 360 degrees, inclusive.
+- `$saturation` — The saturation of the color. Must be a number between 0% and 100%, inclusive.
+- `$lightness` — The lightness of the color. Must be a number between 0% and 100%, inclusive.
+- `$alpha` - The opacity of the color. Must be a number between 0 and 1, inclusive.
+
 ### Example
 
 Create `demo.csss`:
+
+With [`@use`](https://sass-lang.com/documentation/at-rules/use):
+
+```scss
+@use "./node_modules/hsluv-sass/src/hsluv";
+
+.example {
+  color: hsluv.hsluv(23.2, 83.4%, 43.7%);
+  background-color: hsluv.hpluv(250.4, 100%, 59.1%);
+}
+```
+
+With [`@import`](https://sass-lang.com/documentation/at-rules/import):
 
 ```scss
 @import "./node_modules/hsluv-sass/src/hsluv";

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Create `demo.csss`:
 With [`@use`](https://sass-lang.com/documentation/at-rules/use):
 
 ```scss
-@use "./node_modules/hsluv-sass/src/hsluv";
+@use "./node_modules/hsluv-sass" as hsluv;
 
 .example {
   color: hsluv.hsluv(23.2, 83.4%, 43.7%);
@@ -39,7 +39,7 @@ With [`@use`](https://sass-lang.com/documentation/at-rules/use):
 With [`@import`](https://sass-lang.com/documentation/at-rules/import):
 
 ```scss
-@import "./node_modules/hsluv-sass/src/hsluv";
+@import "./node_modules/hsluv-sass";
 
 .example {
   color: hsluv(23.2, 83.4%, 43.7%);

--- a/index.scss
+++ b/index.scss
@@ -1,0 +1,1 @@
+@import "./src/hsluv";

--- a/src/_conversions.scss
+++ b/src/_conversions.scss
@@ -20,10 +20,14 @@
     }
 
     $hsl: (
-      "h": $hue,
-      "s": $saturation,
-      "l": $lightness,
+      h: $hue,
+      s: $saturation,
+      l: $lightness,
     );
+  } @else if (type-of($value: $hsl) != map) {
+    @error "hsluv function with a single parameter must be called with a map of the form (h: $hue, s: $saturation, l: $lightness)";
+  } @else if not (map.get($hsl, h) and map.get($hsl, s) and map.get($hsl, l)) {
+    @error "hsluv function with a single parameter must be called with a map of the form (h: $hue, s: $saturation, l: $lightness)";
   }
 
   @return $hsl;


### PR DESCRIPTION
Resolves #14 

* Adds explicit error handling for the hsl map argument version of the functions.
* Adds an `index.scss` to allow importing from the top level of the npm module.
* Adds documentation for the raw hsl map form of the color functions.