### PR TITLE
New API cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ npm install hsluv-sass
 Create `demo.csss`:
 
 ```scss
-@import "./node_modules/hsluv-sass/src/hsluv";
+@import "./node_modules/hsluv-sass";
 
 .example {
   color: hsluv(23.2, 83.4%, 43.7%);

--- a/index.scss
+++ b/index.scss
@@ -1,0 +1,1 @@
+@import "./src/hsluv";

--- a/src/_conversions.scss
+++ b/src/_conversions.scss
@@ -6,27 +6,17 @@
 @use './conversions/rgb' as rgb;
 
 @function args-hsl($hue, $saturation, $lightness) {
-  $hsl: $hue;
-
-  @if ($saturation and $lightness) {
-    @if unitless($hue) {
-      $hue: $hue * 1deg;
-    }
-    @if unit($saturation) == "%" {
-      $saturation: $saturation / 1%;
-    }
-    @if unit($lightness) == "%" {
-      $lightness: $lightness / 1%;
-    }
-
-    $hsl: (
-      "h": $hue,
-      "s": $saturation,
-      "l": $lightness,
-    );
+  @if unitless($hue) {
+    $hue: $hue * 1deg;
+  }
+  @if unit($saturation) == "%" {
+    $saturation: $saturation / 1%;
+  }
+  @if unit($lightness) == "%" {
+    $lightness: $lightness / 1%;
   }
 
-  @return $hsl;
+  @return ("h": $hue, "s": $saturation, "l": $lightness);
 }
 
 @function hsluv-rgb($hsluv) {

--- a/src/_hsluv.scss
+++ b/src/_hsluv.scss
@@ -1,21 +1,21 @@
 @use './conversions' as conv;
 @use './conversions/xyz' as xyz;
 
-@function hsluv($hue, $saturation: null, $lightness: null) {
+@function hsluv($hue, $saturation, $lightness) {
   $hsluv: conv.args-hsl($hue, $saturation, $lightness);
   $rgb: conv.hsluv-rgb($hsluv);
 
   @return rgb(map-get($rgb, "r"), map-get($rgb, "g"), map-get($rgb, "b"));
 }
 
-@function hpluv($hue, $saturation: null, $lightness: null) {
+@function hpluv($hue, $saturation, $lightness) {
   $hpluv: conv.args-hsl($hue, $saturation, $lightness);
   $rgb: conv.hpluv-rgb($hpluv);
 
   @return rgb(map-get($rgb, "r"), map-get($rgb, "g"), map-get($rgb, "b"));
 }
 
-@function hsluva($hue, $saturation: null, $lightness: null, $alpha: 1) {
+@function hsluva($hue, $saturation, $lightness, $alpha: 1) {
   $hsluv: conv.args-hsl($hue, $saturation, $lightness);
   $rgb: conv.hsluv-rgb($hsluv);
 
@@ -27,7 +27,7 @@
   );
 }
 
-@function hpluva($hue, $saturation: null, $lightness: null, $alpha: 1) {
+@function hpluva($hue, $saturation, $lightness, $alpha: 1) {
   $hpluv: conv.args-hsl($hue, $saturation, $lightness);
   $rgb: conv.hpluv-rgb($hpluv);
 


### PR DESCRIPTION
This makes two changes:

1. Remove `$saturation` and `$lightness` parameter defaults - if these are null you'll get compilation failures.

   ```
   Error: $map: 10deg is not a map.
     ╷
   7 │   $h: map.get($hsluv, "h");
     │       ^^^^^^^^^^^^^^^^^^^^
     ╵
     src/conversions/_lch.scss 7:7  from-hsluv()
     src/_conversions.scss 33:9     hsluv-rgb()
     src/_hsluv.scss 6:9            hsluv()
     demo.scss 4:12                 root stylesheet
   ```
   The removal of these allows a little cleanup in the internal code.
2. Add a top level `/index.scss` file. This allows `@import "./node_modules/hsluv-sass"` instead of `@import "./node_modules/hsluv-sass/src/hsluv";`